### PR TITLE
Don't attempt to load `libXm.so.2` shipped with SWT on Linux

### DIFF
--- a/src/main/java/org/eclipse/swt/internal/C.java
+++ b/src/main/java/org/eclipse/swt/internal/C.java
@@ -13,11 +13,6 @@ package org.eclipse.swt.internal;
 public class C extends Platform {
 
 	static {
-		if ("Linux".equals (System.getProperty ("os.name"))) { //$NON-NLS-1$ //$NON-NLS-2$
-			try {
-				Library.loadLibrary ("libXm.so.2", false); //$NON-NLS-1$
-			} catch (Throwable ex) {}
-		}
 		Library.loadLibrary ("swt"); //$NON-NLS-1$
 	}
 


### PR DESCRIPTION
Instead, `libXm.so.4` available in most Linux distributions should be used (`libswt-motif.so` is linked with `-lXm` at build time).